### PR TITLE
Update gwt-maven-plugin to 1.0-rc-8

### DIFF
--- a/examples/elemental/pom.xml
+++ b/examples/elemental/pom.xml
@@ -15,12 +15,7 @@
             <groupId>com.intendia.gwt.rxgwt</groupId>
             <artifactId>rxgwt</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.intendia.gwt.rxgwt</groupId>
-            <artifactId>rxgwt</artifactId>
-            <version>${project.version}</version>
-            <classifier>sources</classifier>
+            <type>gwt-lib</type>
         </dependency>
         <dependency>
             <groupId>com.intendia.gwt</groupId>

--- a/examples/elemental2/pom.xml
+++ b/examples/elemental2/pom.xml
@@ -15,12 +15,7 @@
             <groupId>com.intendia.gwt.rxgwt</groupId>
             <artifactId>rxgwt</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.intendia.gwt.rxgwt</groupId>
-            <artifactId>rxgwt</artifactId>
-            <version>${project.version}</version>
-            <classifier>sources</classifier>
+            <type>gwt-lib</type>
         </dependency>
         <dependency>
             <groupId>com.intendia.gwt</groupId>

--- a/examples/widgets/pom.xml
+++ b/examples/widgets/pom.xml
@@ -15,12 +15,7 @@
             <groupId>com.intendia.gwt.rxgwt</groupId>
             <artifactId>rxgwt</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.intendia.gwt.rxgwt</groupId>
-            <artifactId>rxgwt</artifactId>
-            <version>${project.version}</version>
-            <classifier>sources</classifier>
+            <type>gwt-lib</type>
         </dependency>
         <dependency>
             <groupId>com.intendia.gwt</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
                 <plugin>
                     <groupId>net.ltgt.gwt.maven</groupId>
                     <artifactId>gwt-maven-plugin</artifactId>
-                    <version>1.0-rc-7</version>
+                    <version>1.0-rc-8</version>
                     <extensions>true</extensions>
                     <configuration>
                         <skipModule>true</skipModule>


### PR DESCRIPTION
With 1.0-rc-8 the additional source dependency of libs (type gwt-lib)
are no longer needed.